### PR TITLE
Instruct sub-agents to act immediately

### DIFF
--- a/prompts/default/agent.system.tool.call_sub.md
+++ b/prompts/default/agent.system.tool.call_sub.md
@@ -4,6 +4,7 @@ you can use subordinates for subtasks
 subordinates can be scientist coder engineer etc
 message field: always describe role, task details goal overview for new subordinate
 delegate specific subtasks not entire task
+new subordinates must begin executing their task immediately and may only create further agents when they need help or when work can be parallelized
 reset arg usage:
   "true": spawn new subordinate
   "false": continue existing subordinate

--- a/python/tools/call_subordinate.py
+++ b/python/tools/call_subordinate.py
@@ -2,6 +2,12 @@ from agent import Agent, UserMessage
 from python.helpers.tool import Tool, Response
 
 
+DEFAULT_SUBORDINATE_SYSTEM_MESSAGE = (
+    "Start working on the assigned task immediately. "
+    "Only create additional agents if you need help or the work can be parallelized."
+)
+
+
 class Delegation(Tool):
 
     async def execute(self, message="", reset="", **kwargs):
@@ -20,7 +26,13 @@ class Delegation(Tool):
 
         # add user message to subordinate agent
         subordinate: Agent = self.agent.get_data(Agent.DATA_NAME_SUBORDINATE)
-        subordinate.hist_add_user_message(UserMessage(message=message, attachments=[]))
+        subordinate.hist_add_user_message(
+            UserMessage(
+                message=message,
+                attachments=[],
+                system_message=[DEFAULT_SUBORDINATE_SYSTEM_MESSAGE],
+            )
+        )
 
         # set subordinate prompt profile if provided, if not, keep original
         prompt_profile = kwargs.get("prompt_profile")


### PR DESCRIPTION
## Summary
- Teach delegated agents to start their tasks immediately and only seek help or parallelize when necessary
- Update delegation prompt documentation to reflect immediate execution and limited agent spawning

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'python')*

------
https://chatgpt.com/codex/tasks/task_e_688b74444fac832b8471d01f186f7c8a